### PR TITLE
Fix Tribute Summoning crashing, and SelectCard(ClientCard) not working

### DIFF
--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -933,7 +933,7 @@ namespace WindBot.Game
             for (int i = 0; i < count; ++i)
             {
                 int id = packet.ReadInt32();
-                LocationInfo info = tribute ? new LocationInfo(packet, _duel.IsFirst) : new LocationInfo();
+                LocationInfo info = !tribute ? new LocationInfo(packet, _duel.IsFirst) : new LocationInfo();
                 if (tribute)
                 {
                     info.controler = packet.ReadByte();


### PR DESCRIPTION
The cause was that, when tributing, InternalOnSelectCard would try to read from the packet to initialize the LocationInfo twice, so it would try to read beyond the end of the stream and crash, and when not tributing, it wouldn't read the LocationInfo from the packet at all, so it couldn't find any specific card. Make it read the right amount once in each case.