### PR TITLE
Add CI for libWindbot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ env:
 install:
 - reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
 - reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "C:\Program Files (x86)\Android\android-sdk" -f
-- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\ndk15c" -f
+- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\android-ndk-r15c" -f
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
 - curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
-- echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:\ndk15c'
+- echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:'
 script:
 - ls "/c/Program Files (x86)/Android/android-sdk"
 - ls "/c/ProgramData/Microsoft"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ env:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
-- choco install mono --x86
 - ./ci/install-sdk-ndk.sh
+# Unspecified dependency for Embeddinator; 64-bit does not work
+- choco install mono --x86
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
-- choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
+- choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 install:
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
+- reg add HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android /v JavaSdkDirectory /t REG_SZ /d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot"
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
+- choco install mono --x86
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ install:
 - choco install visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
-- msbuild.exe -m -p:Configuration=Release WindBot.sln
-- ~/.nuget/packages/embeddinator-4000/0.4.0/tools/Embeddinator-4000.exe bin/Release/libWindbot.dll --gen=Java --platform=Android --outdir=output -c -v
+- msbuild.exe -m -p:Configuration=Release WindBot.sln -v:diag
 before_deploy:
 - cd bin
 - mv Release WindBot

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
-- choco install visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile
+- choco install visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
-- dotnet restore
+- dotnet restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln
 before_deploy:
 - cd bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ git:
 env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
+install:
+- choco install visualstudio2017-workload-xamarinbuildtools
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
-- dotnet build WindBot.csproj --configuration=Release
+- msbuild.exe -m -p:Configuration=Release WindBot.sln
 before_deploy:
 - cd bin
 - mv Release WindBot

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
 - choco install visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
-- msbuild.exe -m -p:Configuration=Release WindBot.sln -v:diag
+- dotnet restore
+- msbuild.exe -m -p:Configuration=Release WindBot.sln
 before_deploy:
 - cd bin
 - mv Release WindBot

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ env:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
 - reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
+- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "C:\Program Files (x86)\Android\android-sdk" -f
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
 script:
-- ls "/c/Program Files (x86)/Android"
-- ls "/c/ProgramData/Microsoft/AndroidNDK64"
+- ls "/c/Program Files (x86)/Android/android-sdk"
+- ls "/c/ProgramData/Microsoft"
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
 install:
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
+- ls 'C:\Program Files\Android\jdk'
 - ./ci/install-sdk-ndk.sh
 script:
-- ls 'C:\Program Files\Android\jdk'
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
-- choco install visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
+- choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
-- dotnet restore WindBot.sln
+- nuget restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln
 before_deploy:
 - cd bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ install:
 - choco install mono --x86
 - curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
 - echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:'
+- "/c/Program Files (x86)/Android/android-sdk/tools/bin/sdkmanager.bat" --sdk_root="/c/Program Files (x86)/Android/android-sdk" "platforms;android-24"
 script:
-- ls "/c/Program Files (x86)/Android/android-sdk"
-- ls "/c/ProgramData/Microsoft"
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
+- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
-- reg add HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android /v JavaSdkDirectory /t REG_SZ /d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot"
 script:
+- ls "/c/Program Files (x86)/Android"
+- ls "/c/ProgramData/Microsoft/AndroidNDK64"
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   - name: "Desktop exe"
     script: dotnet build WindBot.csproj --configuration=Release
     before_deploy:
-    - cd bin && nv Release WindBot
+    - cd bin && mv Release WindBot
     - 7z a -tzip "$ARTIFACT" WindBot
     - mv $ARTIFACT .. && cd ..
   - name: "Android aar"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ git:
 env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
+  # Visual Studio Installer location for the Android SDK
+  - ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
+  # Visual Studio Installer location for an OpenJDK for Android development
+  - JAVA_HOME='C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25'
 install:
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
 - ./ci/install-sdk-ndk.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
-- choco install visualstudio2017-workload-xamarinbuildtools
+- choco install visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - msbuild.exe -m -p:Configuration=Release WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,11 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
-- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
-- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "C:\Program Files (x86)\Android\android-sdk" -f
-- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\android-ndk-r15c" -f
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
-- curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
-- echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:'
-- "/c/Program Files (x86)/Android/android-sdk/tools/bin/sdkmanager.bat" --sdk_root="/c/Program Files (x86)/Android/android-sdk" "platforms;android-24"
+- ./ci/install-sdk-ndk.sh
 script:
+- ls 'C:\Program Files\Android\jdk'
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - nuget restore WindBot.sln
 - msbuild.exe -m -p:Configuration=Release WindBot.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ env:
 install:
 - reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
 - reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "C:\Program Files (x86)\Android\android-sdk" -f
+- reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\ndk15c" -f
 - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
 - choco install mono --x86
+- curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
+- echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:\ndk15c'
 script:
 - ls "/c/Program Files (x86)/Android/android-sdk"
 - ls "/c/ProgramData/Microsoft"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
     repo: ProjectIgnis/windbot
 - provider: releases
   skip_cleanup: true
-  api_key: $DEPLOY_TOKEN
+  api_key: $RELEASES_TOKEN
   file:
     - $ARTIFACT
     - libWindbot.aar

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ env:
   global:
   - ARTIFACT="WindBotIgnite-$(date +%Y-%m-%d)-$TRAVIS_COMMIT.zip"
 install:
-- choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat AdoptOpenJDK8
+- choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
 - choco install mono --x86
-- ls 'C:\Program Files\Android\jdk'
 - ./ci/install-sdk-ndk.sh
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,25 @@ env:
   - ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
   # Visual Studio Installer location for an OpenJDK for Android development
   - JAVA_HOME='C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25'
-install:
-- choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
-- ./ci/install-sdk-ndk.sh
-# Unspecified dependency for Embeddinator; 64-bit does not work
-- choco install mono --x86
-script:
-- export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
-- nuget restore WindBot.sln
-- msbuild.exe -m -p:Configuration=Release WindBot.sln
-before_deploy:
-- cd bin
-- mv Release WindBot
-- 7z a -tzip "$ARTIFACT" WindBot
-- cd ..
+jobs:
+  include:
+  - name: "Desktop exe"
+    script: dotnet build WindBot.csproj --configuration=Release
+    before_deploy:
+    - cd bin && nv Release WindBot
+    - 7z a -tzip "$ARTIFACT" WindBot
+    - mv $ARTIFACT .. && cd ..
+  - name: "Android aar"
+    install:
+    - choco install nuget.commandline visualstudio2017-workload-xamarinbuildtools visualstudio2017-workload-nativemobile visualstudio2017-workload-netcrossplat
+    - ./ci/install-sdk-ndk.sh
+    - choco install mono --x86  # Unspecified dependency for Embeddinator; 64-bit does not work
+    script:
+    - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
+    - nuget restore WindBot.sln
+    - msbuild.exe -m -p:Configuration=Release WindBot.sln
+    before_deploy:
+    - mv output/libWindbot.aar .
 deploy:
 - provider: script
   skip_cleanup: true
@@ -33,6 +38,7 @@ deploy:
   skip_cleanup: true
   api_key: $DEPLOY_TOKEN
   file:
-    - bin/$ARTIFACT
+    - $ARTIFACT
+    - libWindbot.aar
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 script:
 - export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin":$PATH
 - msbuild.exe -m -p:Configuration=Release WindBot.sln
+- ~/.nuget/packages/embeddinator-4000/0.4.0/tools/Embeddinator-4000.exe bin/Release/libWindbot.dll --gen=Java --platform=Android --outdir=output -c -v
 before_deploy:
 - cd bin
 - mv Release WindBot

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # Visual Studio Installer location for the Android SDK
 ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
 # Visual Studio Installer location for an OpenJDK for Android development
-JAVA_HOME='C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25'
+export JAVA_HOME='C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25'
 # These registry entries are normally set through the GUI: Tools\Options\Xamarin\Android Settings
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "$ANDROID_SDK_ROOT" -f
 # Sometimes installed by Microsoft in C:\ProgramData\Microsoft\AndroidNDK64 but not present on CI

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -4,13 +4,14 @@ set -euxo pipefail
 
 # Visual Studio Installer location for the Android SDK
 ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
-
+# Visual Studio Installer location for an OpenJDK for Android development
+JAVA_HOME='C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25'
 # These registry entries are normally set through the GUI: Tools\Options\Xamarin\Android Settings
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "$ANDROID_SDK_ROOT" -f
 # Sometimes installed by Microsoft in C:\ProgramData\Microsoft\AndroidNDK64 but not present on CI
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\android-ndk-r15c" -f
 # Visual Studio Installer provides this JDK for Android development
-reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25" -f
+reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "$JAVA_HOME" -f
 
 # Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
 cd "$ANDROID_SDK_ROOT"

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -2,15 +2,22 @@
 
 set -euxo pipefail
 
-ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
-# These registry entries are normally set through the GUI: Tools\Options\Xamarin\Android Settings
-reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
 # Visual Studio Installer location for the Android SDK
+ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
+
+# These registry entries are normally set through the GUI: Tools\Options\Xamarin\Android Settings
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "$ANDROID_SDK_ROOT" -f
 # Sometimes installed by Microsoft in C:\ProgramData\Microsoft\AndroidNDK64 but not present on CI
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\android-ndk-r15c" -f
+# Visual Studio Installer provides this JDK for Android development
+reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25" -f
+
+# Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
+cd "$ANDROID_SDK_ROOT"
+tools/bin/sdkmanager.bat --sdk_root=. "platforms;android-24"
+cd ..
+
 # Manually install Android NDK r15c, the most recent version that still works with Embeddinator 0.4.0
 curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
-echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:'
-# Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
-"$ANDROID_SDK_ROOT/tools/bin/sdkmanager.bat" --sdk_root="$ANDROID_SDK_ROOT" "platforms;android-24"
+echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c
+7z x android-ndk-r15c-windows-x86_64.zip -o'C:'

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# These are normally set through the GUI: Tools\Options\Xamarin\Android Settings
+reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
+# Microsoft-location for the Android SDK installed with Visual Studio Installer
+reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "C:\Program Files (x86)\Android\android-sdk" -f
+# Sometimes installed by Microsoft in C:\ProgramData\Microsoft\AndroidNDK64 but not present on CI
+reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\android-ndk-r15c" -f
+# Manually install Android NDK r15c, the most recent version that still works with Embeddinator 0.4.0
+curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
+echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:'
+# Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
+"/c/Program Files (x86)/Android/android-sdk/tools/bin/sdkmanager.bat" --sdk_root="/c/Program Files (x86)/Android/android-sdk" "platforms;android-24"

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -15,7 +15,7 @@ reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDir
 
 # Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
 cd "$ANDROID_SDK_ROOT"
-yes | tools/bin/sdkmanager.bat --sdk_root=. "platforms;android-24"
+(yes || true) | tools/bin/sdkmanager.bat --sdk_root=. "platforms;android-24"
 cd -
 
 # Manually install Android NDK r15c, the most recent version that still works with Embeddinator 0.4.0

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -2,10 +2,6 @@
 
 set -euxo pipefail
 
-# Visual Studio Installer location for the Android SDK
-ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
-# Visual Studio Installer location for an OpenJDK for Android development
-export JAVA_HOME='C:\Program Files\Android\jdk\microsoft_dist_openjdk_1.8.0.25'
 # These registry entries are normally set through the GUI: Tools\Options\Xamarin\Android Settings
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "$ANDROID_SDK_ROOT" -f
 # Sometimes installed by Microsoft in C:\ProgramData\Microsoft\AndroidNDK64 but not present on CI

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euxo pipefail
 
-# These are normally set through the GUI: Tools\Options\Xamarin\Android Settings
+ANDROID_SDK_ROOT='C:\Program Files (x86)\Android\android-sdk'
+# These registry entries are normally set through the GUI: Tools\Options\Xamarin\Android Settings
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDirectory -t REG_SZ -d "C:\Program Files\AdoptOpenJDK\jdk-8.0.252.09-hotspot" -f
-# Microsoft-location for the Android SDK installed with Visual Studio Installer
-reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "C:\Program Files (x86)\Android\android-sdk" -f
+# Visual Studio Installer location for the Android SDK
+reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidSdkDirectory -t REG_SZ -d "$ANDROID_SDK_ROOT" -f
 # Sometimes installed by Microsoft in C:\ProgramData\Microsoft\AndroidNDK64 but not present on CI
 reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v AndroidNdkDirectory -t REG_SZ -d "C:\android-ndk-r15c" -f
 # Manually install Android NDK r15c, the most recent version that still works with Embeddinator 0.4.0
 curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip
 echo "970bb2496de0eada74674bb1b06d79165f725696 *android-ndk-r15c-windows-x86_64.zip" | sha1sum -c && 7z x android-ndk-r15c-windows-x86_64.zip -o'C:'
 # Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
-"/c/Program Files (x86)/Android/android-sdk/tools/bin/sdkmanager.bat" --sdk_root="/c/Program Files (x86)/Android/android-sdk" "platforms;android-24"
+"$ANDROID_SDK_ROOT/tools/bin/sdkmanager.bat" --sdk_root="$ANDROID_SDK_ROOT" "platforms;android-24"

--- a/ci/install-sdk-ndk.sh
+++ b/ci/install-sdk-ndk.sh
@@ -15,8 +15,8 @@ reg add 'HKCU\SOFTWARE\Xamarin\VisualStudio\15.0_e43b966e\Android' -v JavaSdkDir
 
 # Manually install Android SDK Platform 24, the most recent version that still works with Embeddinator 0.4.0
 cd "$ANDROID_SDK_ROOT"
-tools/bin/sdkmanager.bat --sdk_root=. "platforms;android-24"
-cd ..
+yes | tools/bin/sdkmanager.bat --sdk_root=. "platforms;android-24"
+cd -
 
 # Manually install Android NDK r15c, the most recent version that still works with Embeddinator 0.4.0
 curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://dl.google.com/android/repository/android-ndk-r15c-windows-x86_64.zip

--- a/libWindbot.csproj
+++ b/libWindbot.csproj
@@ -126,6 +126,12 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>set E4K_OUTPUT="$(SolutionDir)output"
+if exist %25E4K_OUTPUT%25 rmdir /S /Q %25E4K_OUTPUT%25
+"$(NuGetPackageRoot)embeddinator-4000\0.4.0\tools\Embeddinator-4000.exe" "$(TargetPath)" --gen=Java --platform=Android --outdir=%25E4K_OUTPUT%25 -c -v
+</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/libWindbot.csproj
+++ b/libWindbot.csproj
@@ -126,13 +126,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>set E4K_OUTPUT="$(SolutionDir)output"
-if exist %25E4K_OUTPUT%25 rmdir /S /Q %25E4K_OUTPUT%25
-"$(NuGetPackageRoot)embeddinator-4000\0.4.0\tools\Embeddinator-4000.exe" "$(TargetPath)" --gen=Java --platform=Android --outdir=%25E4K_OUTPUT%25 -c -v
-</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
One fast job to build for desktop and uploading those release archives.
One slower job to build the Android aar.

Closes #10. Documentation to come since this differs somewhat from doing it yourself on your machine. 