### PR TITLE
Do not leak activation limits across turns

### DIFF
--- a/ExecutorBase/Game/GameAI.cs
+++ b/ExecutorBase/Game/GameAI.cs
@@ -95,6 +95,7 @@ namespace WindBot.Game
         /// </summary>
         public void OnNewTurn()
         {
+            _activatedCards.Clear();
             Executor.OnNewTurn();
         }
 


### PR DESCRIPTION
The activated card limit is intended to prevent loops of card activations by the AI:

eg: 
An AI activate Dark Ruler No More so the opponent does not take effect damage
An AI activates Imperial Iron Wall
An AI controls Deskbot001 and Cannon Solder on the field
An AI triggers the Quillbolt Hedgehog in the grave

In this state an AI could activate the Quillbolt Hedgehog and Cannon soldier an infinite number of times and the player opponent would never have a turn. 

The activation limit prevents this by keeping track of the times a card has been activated, and not triggering any CardExecutor if the number reaches 9.

The bug is that this activation limit is never reset across turns or even across duels.
So if Polymerization has been activated 9 times total across 5 different duels with the AI opponent they will never activate Polymerization in future duels until you leave the match.

This change fixes the issue by resetting the count each turn.