### PR TITLE
Server mode: Expect room id in http get request

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -179,6 +179,9 @@ namespace WindBot
                     string version = HttpUtility.ParseQueryString(RawUrl).Get("version");
                     if (version != null)
                         Info.Version = Int16.Parse(version);
+                    string RoomId = HttpUtility.ParseQueryString(RawUrl).Get("roomid");
+                    if (RoomId != null)
+                        Info.RoomId = Int32.Parse(RoomId);
                     string password = HttpUtility.ParseQueryString(RawUrl).Get("password");
                     if (password != null)
                         Info.HostInfo = password;


### PR DESCRIPTION
Before we weren't getting a room id parsed in from the http request when running in server mode.
This hasn't been tested, because .net framework required to run this is too old to even download anymore.
This should work, as it's based off the "hand" lines, which work, and does the same thing, just adapted to the RoomId parameter.
This only has an effect, if WindBot is run in server mode